### PR TITLE
Use --server PID instead of -a PID.

### DIFF
--- a/lib/autotest.rb
+++ b/lib/autotest.rb
@@ -469,7 +469,7 @@ class Autotest
       loader = "%w[#{files.join " "}].each do |f| load f; end"
       re = Regexp.union(re).to_s.gsub(/-mix/, "")
 
-      cmds << "#{ruby_cmd} -e '#{loader}' -- -a #{$$} -n '/#{re}/'"
+      cmds << "#{ruby_cmd} -e '#{loader}' -- --server #{$$} -n '/#{re}/'"
     end
 
     cmds.join "#{SEP} "


### PR DESCRIPTION
mintiest-server does not provide a short form of `-a PID` for its option `--server`, resulting in an unknown argument.
