### PR TITLE
Default died hook needs to be last

### DIFF
--- a/lib/autotest.rb
+++ b/lib/autotest.rb
@@ -260,7 +260,11 @@ class Autotest
     hook :quit
     puts
   rescue Exception => err
-    hook(:died, err) or raise err
+    hook(:died, err) or (
+      warn "Unhandled exception: #{err}"
+      warn err.backtrace.join("\n  ")
+      warn "Quitting"
+    )
   ensure
     Minitest::Server.stop
   end
@@ -702,12 +706,6 @@ class Autotest
 
   def self.add_hook name, &block
     HOOKS[name] << block
-  end
-
-  add_hook :died do |at, err|
-    warn "Unhandled exception: #{err}"
-    warn err.backtrace.join("\n  ")
-    warn "Quitting"
   end
 
   ############################################################


### PR DESCRIPTION
the add_hook call makes the default hook first. it shouldn't run if
someone else handles the exception.

Also, the or raise makes the error output twice.

this was fixed in https://github.com/seattlerb/zentest/issues/44