### PR TITLE
Add autotest/bundler tip to README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -78,6 +78,14 @@ Then add the following to the ".autotest" file:
 
     require "autotest/spec"
 
+If you use autotest/bundler, make sure your Gemfile includes
+the minitest-autotest gem. That way, the minitest-server plugin
+(which is used by minitest-autotest) will be put on the load path
+by bundler, and will be loaded by minitest. Otherwise, you may
+get the following error message:
+
+    invalid option: --server
+
 == REQUIREMENTS:
 
 * minitest 5+

--- a/README.rdoc
+++ b/README.rdoc
@@ -78,11 +78,11 @@ Then add the following to the ".autotest" file:
 
     require "autotest/spec"
 
-If you use autotest/bundler, make sure your Gemfile includes
-the minitest-autotest gem. That way, the minitest-server plugin
-(which is used by minitest-autotest) will be put on the load path
-by bundler, and will be loaded by minitest. Otherwise, you may
-get the following error message:
+If you use autotest/bundler, include minitest-autotest in your Gemfile:
+
+    gem "minitest-autotest"
+
+Otherwise, you may get this error message when running autotest:
 
     invalid option: --server
 


### PR DESCRIPTION
This is my attempt at including a tip for the gotcha I encountered when using `autotest/bundler` + `minitest-autotest`, as encouraged [in this comment](https://github.com/seattlerb/minitest-autotest/issues/10#issuecomment-165042164).

I think that the tips section of the README is the most appropriate place, and hope that my language is not too verbose!