### PR TITLE
rm reference to example_dot_autotest.rb

### DIFF
--- a/lib/autotest.rb
+++ b/lib/autotest.rb
@@ -27,8 +27,6 @@ require "rbconfig"
 #
 # The available hooks are listed in +ALL_HOOKS+.
 #
-# See example_dot_autotest.rb for more details.
-#
 # If a hook returns a true value, it signals to autotest that the hook
 # was handled and should not continue executing hooks.
 #


### PR DESCRIPTION
This is likely an article from the split off from the zentest gem?