### PR TITLE
Fix -rubygems deprecation on ruby 2.5

### DIFF
--- a/lib/autotest.rb
+++ b/lib/autotest.rb
@@ -539,7 +539,7 @@ class Autotest
   # Returns the base of the ruby command.
 
   def ruby_cmd
-    "#{prefix}#{ruby} -I#{libs} -rubygems"
+    "#{prefix}#{ruby} -I#{libs} -rrubygems"
   end
 
   ##


### PR DESCRIPTION
Get rid of the following deprecation warning on ruby 2.5.1:

```
`ubygems.rb' is deprecated, and will be removed on or after 2018-12-01. Remove `-rubygems' from your command-line, or use `-r rubygems' instead
```

Fixes #14 